### PR TITLE
Remove scheduled job from GitHub Actions workflow

### DIFF
--- a/.github/workflows/hourly-news-search.yml
+++ b/.github/workflows/hourly-news-search.yml
@@ -1,8 +1,6 @@
 name: Hourly News Search
 
 on:
-  schedule:
-    - cron: '*/15 * * * *'  # Run every 15 minutes
   workflow_dispatch:  # Allow manual triggering
     inputs:
       debug:


### PR DESCRIPTION
Disabled the automated 15-minute cron schedule, keeping only manual workflow_dispatch trigger.

🤖 Generated with [Claude Code](https://claude.ai/code)